### PR TITLE
fix: panic consuming when reciever closed early due to limit

### DIFF
--- a/crates/tui/src/component/ui.rs
+++ b/crates/tui/src/component/ui.rs
@@ -205,7 +205,10 @@ impl Ui {
                             .and_then(|r| r.timestamp().to_millis())
                             .unwrap_or(0);
                         for record in bulk_of_records {
-                            tx_dd.send(record.detach()).unwrap();
+                            if tx_dd.send(record.detach()).is_err() {
+                                token.cancel();
+                                break;
+                            }
                         }
                         if current_time.elapsed() > Duration::from_secs(13) {
                             current_time = Instant::now();


### PR DESCRIPTION
While searching for records, once the "search-engine" task is done, it will drop the `rx_dd` channel receiver which was moved into it. The task can close earlier than expected when a query limit is hit (via `token_cloned.cancel()`), which will cause the `tx_dd` channel sender to panic when `.send()` is next called during processing.

Rather than unwrapping the send which will error if the `UnboundedReciever` was dropped, we can utilize the `CancellationToken` and pop out early :)

We could return a `future::ready(())` instead which would skip the checkpoint notification if that's preferred.

**Panic Trace**:
```sh
thread 'tokio-runtime-worker' (25909782) panicked at crates/tui/src/component/ui.rs:208:57:
called `Result::unwrap()` on an `Err` value: SendError { .. }
stack backtrace:
   0:        0x105c6d3bc - ___jit_debug_register_code
   1:        0x105c92568 - ___jit_debug_register_code
   2:        0x105c6dbf4 - ___jit_debug_register_code
   3:        0x105c6a3a0 - ___jit_debug_register_code
   4:        0x105c6a288 - ___jit_debug_register_code
   5:        0x104ddf63c - __mh_execute_header
   6:        0x105c6a69c - ___jit_debug_register_code
   7:        0x105c6a4a4 - ___jit_debug_register_code
   8:        0x105c69a9c - ___jit_debug_register_code
   9:        0x105c680d4 - ___jit_debug_register_code
  10:        0x105d3a4b0 - ___jit_debug_register_code
  11:        0x105d3a1a0 - ___jit_debug_register_code
  12:        0x104e14e84 - __mh_execute_header
  13:        0x104e3d47c - __mh_execute_header
```

This can be reproduced by setting a low `limit` while querying against a large set of records, e.g.:
```sql
from end - 10000 limit 1
```

or more practically something like:
```sql
from "2026-01-12T07:00:00.000+00:00" where key == "d53ed8c1-ce26-44a1-b321-c907a30c47ec" limit 1
```