### PR TITLE
fix: clipboard content lost on Linux after copy

### DIFF
--- a/crates/tui/src/component/mod.rs
+++ b/crates/tui/src/component/mod.rs
@@ -78,7 +78,7 @@ pub(crate) trait WithHeight: Component {
     }
 }
 
-pub(crate) trait Component: Send + Sync {
+pub(crate) trait Component: Send {
     fn register_action_handler(&mut self, _tx: UnboundedSender<Action>) {}
 
     fn id(&self) -> ComponentName;

--- a/crates/tui/src/component/records_component.rs
+++ b/crates/tui/src/component/records_component.rs
@@ -1,7 +1,6 @@
 //! Component showing in real time incoming kafka records.
 
 use app::{configuration::TimestampFormat, search::ValidSearchQuery};
-use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use lib::ExportedKafkaRecord;
 use ratatui::{
@@ -15,13 +14,7 @@ use thousands::Separable;
 use throbber_widgets_tui::ThrobberState;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{
-    Action,
-    action::{Level, Notification},
-    component::RecordsReceiver,
-    error::TuiError,
-    records_buffer::RecordsBuffer,
-};
+use crate::{Action, component::RecordsReceiver, error::TuiError, records_buffer::RecordsBuffer};
 
 use super::{Component, ComponentName, Shortcut, State, styles};
 
@@ -235,13 +228,13 @@ impl Component for RecordsComponent {
             KeyCode::Char('c') => {
                 if let Some(s) = self.state.selected() {
                     let record = self.records.get(s).unwrap();
-                    let mut ctx = ClipboardContext::new().unwrap();
                     let exported_record: ExportedKafkaRecord = record.into();
-                    self.action_tx.as_ref().unwrap().send(Action::Notification(
-                        Notification::new(Level::Info, "Copied to clipboard".to_string()),
-                    ))?;
-                    ctx.set_contents(serde_json::to_string_pretty(&exported_record)?)
-                        .unwrap();
+                    self.action_tx
+                        .as_ref()
+                        .unwrap()
+                        .send(Action::CopyToClipboard(serde_json::to_string_pretty(
+                            &exported_record,
+                        )?))?;
                 }
             }
             KeyCode::Char('f') => self.follow(!self.follow)?,

--- a/crates/tui/src/component/root_component.rs
+++ b/crates/tui/src/component/root_component.rs
@@ -1,6 +1,7 @@
 //! This component is handles the main layout of the TUI
 //! and renders components based on the current context.
-use copypasta::{ClipboardContext, ClipboardProvider};
+use copypasta::{ClipboardContext, ClipboardProvider, nop_clipboard::NopClipboardContext};
+
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -36,6 +37,7 @@ pub(crate) struct RootComponent {
     focus_history: Vec<ComponentName>,
     focus_order: Vec<ComponentName>,
     action_tx: Option<UnboundedSender<Action>>,
+    clipboard: Box<dyn ClipboardProvider + Send>,
 }
 
 impl RootComponent {
@@ -86,6 +88,15 @@ impl RootComponent {
                 (id, c)
             })
             .collect();
+        let clipboard: Box<dyn ClipboardProvider + Send> = match ClipboardContext::new() {
+            Ok(context) => Box::new(context),
+            Err(err) => {
+                warn!(
+                    "Failed to initialize clipboard context: {err}. Using NopClipboardContext instead."
+                );
+                Box::new(NopClipboardContext::new().unwrap())
+            }
+        };
         Self {
             components,
             views: vec![ComponentName::TopicsAndRecords],
@@ -93,6 +104,7 @@ impl RootComponent {
             focus_history: vec![],
             state,
             action_tx: None,
+            clipboard,
         }
     }
 
@@ -349,7 +361,6 @@ impl Component for RootComponent {
                 self.notify_footer()?;
             }
             Action::CopyToClipboard(ref content) => {
-                let mut ctx = ClipboardContext::new().unwrap();
                 self.action_tx
                     .as_ref()
                     .unwrap()
@@ -357,7 +368,7 @@ impl Component for RootComponent {
                         Level::Info,
                         "Copied to clipboard".to_string(),
                     )))?;
-                ctx.set_contents(content.to_string()).unwrap();
+                self.clipboard.set_contents(content.to_string()).unwrap();
             }
             _ => (),
         }


### PR DESCRIPTION
ClipboardContext was created locally and dropped immediately, causing the app to lose X11/Wayland selection ownership before any paste.

Move the context into RootComponent as a persistent field for the app's lifetime. Route RecordsComponent's direct clipboard call through Action::CopyToClipboard so all copy paths go via one place.

Additionally, remove the unnecessary Sync requirements for Component trait, as there's no direct need used throughout the code for it to be Sync.

